### PR TITLE
Remove badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-## property-pro-lite
+# Property Pro Lite
 Property Pro Lite is a platform where people can create and/or search properties for sale or rent.
 
-## badges
-[![Build Status](https://travis-ci.org/robert-odoch/property-pro-lite.svg?branch=develop)](https://travis-ci.org/robert-odoch/property-pro-lite)
-[![Coverage Status](https://coveralls.io/repos/github/robert-odoch/property-pro-lite/badge.svg?branch=develop)](https://coveralls.io/github/robert-odoch/property-pro-lite?branch=develop)
-[![Maintainability](https://api.codeclimate.com/v1/badges/cd2242b1a76ced2c3c22/maintainability)](https://codeclimate.com/github/robert-odoch/property-pro-lite/maintainability)
+## API Moved
+I was finding it hard to manage the API and UI in the same repository so I decided to move the API code
+to it's own [repository!](https://github.com/robert-odoch/adc-challenge-2).


### PR DESCRIPTION
Badges are for the API code so move them and indicate new repository